### PR TITLE
feat: adiciona fluxo de envio de email via Mailto no histórico

### DIFF
--- a/docs/historico-email-mailto.md
+++ b/docs/historico-email-mailto.md
@@ -1,0 +1,62 @@
+# Envio de Email no Histórico de Pagamentos — Mailto
+
+## Contexto
+
+O sistema possuía um fluxo de envio de comprovantes via **VBA Script** (Excel + Outlook Clássico no Windows). Com a migração para MacBook, o Outlook Clássico não está disponível, tornando o fluxo VBA inoperante no Mac.
+
+A solução adotada foi adicionar uma segunda opção de envio via **Mailto**, que funciona com qualquer cliente de email configurado no sistema operacional (Outlook Moderno, Apple Mail, etc.), sem necessidade de APIs externas ou cadastros adicionais.
+
+---
+
+## O que foi alterado
+
+### `src/app/historico/email-vba-dialog.tsx`
+
+Arquivo principal do fluxo de email. As mudanças adicionam uma camada de seleção de método sem remover nem alterar o fluxo VBA existente.
+
+**Novas adições:**
+
+- **Tipo `Step`** (`'method' | 'vba' | 'mailto'`): controla em qual etapa do dialog o usuário está.
+- **Tela de seleção de método** (step `'method'`): ao abrir o dialog, o usuário vê dois cards — *VBA Script* e *Mailto* — com botão de voltar no header após a escolha.
+- **Função `generateMailtoLink(p)`**: gera um link `mailto:` com destinatário, assunto (`Comprovante de Pagamento`) e corpo pré-preenchido (nome, descrição, valor em USDT e hash da transação), tudo URL-encoded.
+- **Estado `mailtoGerados`**: lista de links gerados após clicar em "Gerar links de email".
+- **Função `handleAbrirEmails()`**: gera os links mailto para os pagamentos selecionados, chama `marcarEmailsEnviados` no banco e dispara `router.refresh()` após a conclusão.
+- **Step `'mailto'`**: UI idêntica ao fluxo VBA na seleção de pagamentos, mas sem campo de remetente. O botão "Gerar links de email" gera os links e exibe uma lista clicável — um item por prestador — que abre o cliente de email padrão com o email já montado.
+- **`router.refresh()`** chamado dentro do `startTransition` após `await marcarEmailsEnviados`, garantindo que o banco já foi atualizado antes do refresh da página.
+
+**Fluxo do usuário (Mailto):**
+
+1. Clicar em **Enviar Email** → selecionar **Mailto**
+2. Selecionar os pagamentos desejados (apenas USDT/USDC com hash e email pendente)
+3. Clicar em **Gerar links de email**
+4. Clicar em cada nome na lista gerada → Outlook abre com email pré-preenchido
+5. Trocar a caixa de envio para a conta correta e confirmar o envio
+6. Os pagamentos são marcados como `email_enviado = true` automaticamente
+
+**Observação sobre remetente:** O protocolo `mailto:` não suporta definir o campo `From`. O usuário deve selecionar manualmente a caixa de envio correta no Outlook ao abrir cada email.
+
+---
+
+### `src/app/historico/page.tsx`
+
+- Adicionado `export const dynamic = 'force-dynamic'` para desabilitar o cache do Next.js nesta rota, garantindo que os dados do banco sejam sempre buscados frescos.
+- Adicionado o componente `<RefreshButton />` ao lado do botão "Enviar Email".
+
+---
+
+### `src/app/historico/refresh-button.tsx` *(novo)*
+
+Componente cliente simples com um botão **Atualizar** que executa `window.location.reload()`. Permite ao usuário forçar a atualização dos status de email na página após o envio.
+
+---
+
+## Decisões técnicas
+
+| Decisão | Motivo |
+|---|---|
+| Manter VBA + adicionar Mailto | VBA ainda funciona no Windows; não havia motivo para remover |
+| `window.location.reload()` no botão Atualizar | `router.refresh()` do Next.js não estava invalidando o cache corretamente no ambiente local |
+| `force-dynamic` na página | Evita que o Next.js sirva dados em cache após atualizações no banco |
+| Sem campo de remetente no Mailto | `mailto:` não suporta `From`; o cliente de email usa a conta padrão configurada |
+| Links clicáveis por prestador | Mais confiável que abrir múltiplas janelas via JavaScript, que pode ser bloqueado pelo browser |
+| `marcarEmailsEnviados` chamado ao gerar links | Mesmo comportamento do VBA — marca como enviado no momento em que o usuário inicia o envio |

--- a/src/app/historico/email-vba-dialog.tsx
+++ b/src/app/historico/email-vba-dialog.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import { useState, useTransition, useEffect } from 'react'
-import { Mail, X, Copy, Check, Code2, AlertTriangle, Loader2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Mail, X, Copy, Check, Code2, AlertTriangle, Loader2, ChevronLeft, ExternalLink } from 'lucide-react'
 import { marcarEmailsEnviados } from './actions'
+
+type Step = 'method' | 'vba' | 'mailto'
 
 const STORAGE_KEY = 'email_remetentes_salvos'
 const MAX_SAVED = 5
@@ -122,17 +125,44 @@ ${sentOnBehalf}${bcc}            .Display
 End Sub`
 }
 
+function generateMailtoLink(p: HistoricoParaEmail): string {
+  const descricao = formatDescricao(p)
+  const valorFmt = p.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+  const body = [
+    `Olá, ${p.prestador_nome}!`,
+    '',
+    'Segue o comprovante referente ao pagamento abaixo:',
+    '',
+    descricao,
+    `Valor: ${valorFmt} USDT`,
+    `HASH: ${p.comprovante}`,
+    '',
+    'Atenciosamente,',
+  ].join('\n')
+  return `mailto:${encodeURIComponent(p.prestador_email ?? '')}?subject=${encodeURIComponent('Comprovante de Pagamento')}&body=${encodeURIComponent(body)}`
+}
+
+interface MailtoItem {
+  id: string
+  nome: string
+  email: string
+  link: string
+}
+
 interface Props {
   pagamentos: HistoricoParaEmail[]
 }
 
 export default function EmailVbaDialog({ pagamentos }: Props) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
+  const [step, setStep] = useState<Step>('method')
   const [sender, setSender] = useState('')
   const [savedEmails, setSavedEmails] = useState<string[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [vba, setVba] = useState('')
   const [copied, setCopied] = useState(false)
+  const [mailtoGerados, setMailtoGerados] = useState<MailtoItem[]>([])
   const [isPending, startTransition] = useTransition()
 
   useEffect(() => {
@@ -140,6 +170,7 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
   }, [open])
 
   const semEmail = pagamentos.filter(p => !p.prestador_email)
+  const elegíveis = pagamentos.filter(p => p.prestador_email)
 
   function toggle(id: string) {
     setSelected(prev => {
@@ -148,16 +179,17 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
       return next
     })
     setVba('')
+    setMailtoGerados([])
   }
 
   function toggleAll() {
-    const elegíveis = pagamentos.filter(p => p.prestador_email)
     if (selected.size === elegíveis.length) {
       setSelected(new Set())
     } else {
       setSelected(new Set(elegíveis.map(p => p.id)))
     }
     setVba('')
+    setMailtoGerados([])
   }
 
   function handleGerar() {
@@ -169,6 +201,7 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
     startTransition(async () => {
       await marcarEmailsEnviados(ids)
       setSelected(new Set())
+      router.refresh()
     })
   }
 
@@ -185,15 +218,46 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
     })
   }
 
+  function handleAbrirEmails() {
+    const rows = pagamentos.filter(p => selected.has(p.id))
+    const links: MailtoItem[] = rows.map(p => ({
+      id: p.id,
+      nome: p.prestador_nome,
+      email: p.prestador_email ?? '',
+      link: generateMailtoLink(p),
+    }))
+    setMailtoGerados(links)
+    startTransition(async () => {
+      await marcarEmailsEnviados(rows.map(p => p.id))
+      setSelected(new Set())
+      router.refresh()
+    })
+  }
+
+  function handleClose() {
+    setOpen(false)
+  }
+
   function handleOpen() {
+    setStep('method')
     setSelected(new Set())
     setVba('')
     setCopied(false)
+    setMailtoGerados([])
     setOpen(true)
   }
 
-  const elegíveis = pagamentos.filter(p => p.prestador_email)
-  const selectedRows = pagamentos.filter(p => selected.has(p.id))
+  function handleBack() {
+    setStep('method')
+    setSelected(new Set())
+    setVba('')
+    setMailtoGerados([])
+  }
+
+  const headerTitle =
+    step === 'vba' ? 'VBA Script — Outlook Clássico' :
+    step === 'mailto' ? 'Mailto — Cliente de email' :
+    'Enviar comprovantes por email'
 
   return (
     <>
@@ -207,183 +271,366 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
 
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div className="absolute inset-0 bg-black/60" onClick={() => setOpen(false)} />
+          <div className="absolute inset-0 bg-black/60" onClick={handleClose} />
           <div className="relative z-10 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-2xl border border-border bg-background shadow-2xl">
 
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-5 border-b border-border">
               <div className="flex items-center gap-2">
+                {step !== 'method' && (
+                  <button
+                    onClick={handleBack}
+                    className="rounded-lg p-1.5 text-muted-foreground hover:bg-muted transition-colors"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </button>
+                )}
                 <Mail className="h-5 w-5 text-muted-foreground" />
-                <h2 className="text-base font-semibold text-foreground">Enviar comprovantes por email</h2>
+                <h2 className="text-base font-semibold text-foreground">{headerTitle}</h2>
               </div>
-              <button onClick={() => setOpen(false)} className="rounded-lg p-1.5 text-muted-foreground hover:bg-muted transition-colors">
+              <button onClick={handleClose} className="rounded-lg p-1.5 text-muted-foreground hover:bg-muted transition-colors">
                 <X className="h-4 w-4" />
               </button>
             </div>
 
-            <div className="px-6 py-5 space-y-5">
+            {/* ── Step: seleção de método ── */}
+            {step === 'method' && (
+              <div className="px-6 py-6 space-y-5">
+                <p className="text-sm text-muted-foreground">
+                  Selecione como deseja enviar os comprovantes.{' '}
+                  <span className="font-medium text-foreground">
+                    {pagamentos.length} pagamento{pagamentos.length !== 1 ? 's' : ''} disponível{pagamentos.length !== 1 ? 'is' : ''} para envio.
+                  </span>
+                </p>
 
-              {/* Remetente */}
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1.5">
-                  Email do remetente
-                </label>
-                <input
-                  type="email"
-                  value={sender}
-                  onChange={e => { setSender(e.target.value); setVba('') }}
-                  placeholder="financeiro@suaempresa.com.br"
-                  className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-                <p className="mt-1 text-xs text-muted-foreground">Usado como remetente e BCC. Sua assinatura do Outlook é incluída automaticamente.</p>
+                {pagamentos.length === 0 ? (
+                  <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
+                    Nenhum pagamento USDT com hash cadastrado neste mês.
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-2 gap-4">
+                    <button
+                      onClick={() => setStep('vba')}
+                      className="flex flex-col items-center text-center gap-3 rounded-xl border border-border bg-card p-6 hover:border-primary/50 hover:bg-primary/5 transition-all group"
+                    >
+                      <div className="rounded-lg bg-muted p-3 group-hover:bg-primary/10 transition-colors">
+                        <Code2 className="h-6 w-6 text-muted-foreground group-hover:text-primary transition-colors" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">VBA Script</p>
+                        <p className="text-xs text-muted-foreground mt-1">Windows · Excel · Outlook Clássico</p>
+                      </div>
+                    </button>
 
-                {savedEmails.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {savedEmails.map(email => (
-                      <span
-                        key={email}
-                        className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs text-muted-foreground"
-                      >
-                        <button
-                          type="button"
-                          onClick={() => { setSender(email); setVba('') }}
-                          className="hover:text-foreground transition-colors"
-                        >
-                          {email}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveSaved(email)}
-                          className="ml-0.5 rounded-full hover:text-foreground transition-colors"
-                          aria-label="Remover"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </span>
-                    ))}
+                    <button
+                      onClick={() => setStep('mailto')}
+                      className="flex flex-col items-center text-center gap-3 rounded-xl border border-border bg-card p-6 hover:border-primary/50 hover:bg-primary/5 transition-all group"
+                    >
+                      <div className="rounded-lg bg-muted p-3 group-hover:bg-primary/10 transition-colors">
+                        <ExternalLink className="h-6 w-6 text-muted-foreground group-hover:text-primary transition-colors" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">Mailto</p>
+                        <p className="text-xs text-muted-foreground mt-1">Mac · Outlook Moderno · Apple Mail</p>
+                      </div>
+                    </button>
                   </div>
                 )}
               </div>
+            )}
 
-              {/* Estado vazio */}
-              {pagamentos.length === 0 && (
-                <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
-                  Nenhum pagamento USDT com hash cadastrado neste mês.
-                </div>
-              )}
+            {/* ── Step: VBA (fluxo original, sem alterações) ── */}
+            {step === 'vba' && (
+              <div className="px-6 py-5 space-y-5">
 
-              {/* Aviso sem email */}
-              {semEmail.length > 0 && (
-                <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
-                  <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-                  <span>
-                    {semEmail.map(p => p.prestador_nome).join(', ')} não {semEmail.length === 1 ? 'possui' : 'possuem'} email cadastrado e {semEmail.length === 1 ? 'não pode' : 'não podem'} ser selecionado{semEmail.length === 1 ? '' : 's'}.
-                  </span>
-                </div>
-              )}
-
-              {/* Lista de pagamentos */}
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <label className="text-sm font-medium text-foreground">
-                    Selecionar pagamentos ({selected.size} selecionado{selected.size !== 1 ? 's' : ''})
+                {/* Remetente */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                    Email do remetente
                   </label>
-                  {elegíveis.length > 0 && (
-                    <button
-                      onClick={toggleAll}
-                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {selected.size === elegíveis.length ? 'Desmarcar todos' : 'Selecionar todos'}
-                    </button>
+                  <input
+                    type="email"
+                    value={sender}
+                    onChange={e => { setSender(e.target.value); setVba('') }}
+                    placeholder="financeiro@suaempresa.com.br"
+                    className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">Usado como remetente e BCC. Sua assinatura do Outlook é incluída automaticamente.</p>
+
+                  {savedEmails.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {savedEmails.map(email => (
+                        <span
+                          key={email}
+                          className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs text-muted-foreground"
+                        >
+                          <button
+                            type="button"
+                            onClick={() => { setSender(email); setVba('') }}
+                            className="hover:text-foreground transition-colors"
+                          >
+                            {email}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveSaved(email)}
+                            className="ml-0.5 rounded-full hover:text-foreground transition-colors"
+                            aria-label="Remover"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
                   )}
                 </div>
 
-                <div className="space-y-2 max-h-64 overflow-y-auto rounded-lg border border-border p-1">
-                  {pagamentos.map(p => {
-                    const temEmail = !!p.prestador_email
-                    const isChecked = selected.has(p.id)
-                    const descricao = formatDescricao(p)
-                    const valorFmt = p.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+                {/* Estado vazio */}
+                {pagamentos.length === 0 && (
+                  <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
+                    Nenhum pagamento USDT com hash cadastrado neste mês.
+                  </div>
+                )}
 
-                    return (
-                      <label
-                        key={p.id}
-                        className={`flex items-start gap-3 rounded-lg px-3 py-2.5 cursor-pointer transition-colors ${
-                          temEmail
-                            ? isChecked ? 'bg-primary/10 border border-primary/30' : 'hover:bg-muted border border-transparent'
-                            : 'opacity-40 cursor-not-allowed border border-transparent'
-                        }`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={isChecked}
-                          disabled={!temEmail}
-                          onChange={() => toggle(p.id)}
-                          className="mt-0.5 h-4 w-4 rounded border-input accent-primary"
-                        />
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <span className="text-sm font-medium text-foreground">{p.prestador_nome}</span>
-                            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                              p.tipo === 'comissao' ? 'bg-emerald-500/15 text-emerald-500' : 'bg-blue-500/15 text-blue-500'
-                            }`}>
-                              {p.tipo === 'comissao' ? 'Comissão' : 'Salário'}
-                            </span>
-                            <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} USDT</span>
-                          </div>
-                          <p className="text-xs text-muted-foreground mt-0.5 truncate">{descricao}</p>
-                          {temEmail && (
-                            <p className="text-xs text-muted-foreground/60 mt-0.5">{p.prestador_email}</p>
-                          )}
-                        </div>
-                      </label>
-                    )
-                  })}
-                </div>
-              </div>
+                {/* Aviso sem email */}
+                {semEmail.length > 0 && (
+                  <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                    <span>
+                      {semEmail.map(p => p.prestador_nome).join(', ')} não {semEmail.length === 1 ? 'possui' : 'possuem'} email cadastrado e {semEmail.length === 1 ? 'não pode' : 'não podem'} ser selecionado{semEmail.length === 1 ? '' : 's'}.
+                    </span>
+                  </div>
+                )}
 
-              {/* Botão gerar */}
-              <button
-                onClick={handleGerar}
-                disabled={selected.size === 0 || isPending}
-                className="w-full inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Code2 className="h-4 w-4" />}
-                {isPending ? 'Registrando...' : `Gerar Script VBA (${selected.size} email${selected.size !== 1 ? 's' : ''})`}
-              </button>
-
-              {/* Output VBA */}
-              {vba && (
+                {/* Lista de pagamentos */}
                 <div>
                   <div className="flex items-center justify-between mb-2">
-                    <label className="text-sm font-medium text-foreground">Script VBA gerado</label>
-                    <button
-                      onClick={handleCopy}
-                      className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-                        copied
-                          ? 'bg-emerald-500/15 text-emerald-500'
-                          : 'bg-muted text-muted-foreground hover:text-foreground'
-                      }`}
-                    >
-                      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                      {copied ? 'Copiado!' : 'Copiar'}
-                    </button>
+                    <label className="text-sm font-medium text-foreground">
+                      Selecionar pagamentos ({selected.size} selecionado{selected.size !== 1 ? 's' : ''})
+                    </label>
+                    {elegíveis.length > 0 && (
+                      <button
+                        onClick={toggleAll}
+                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        {selected.size === elegíveis.length ? 'Desmarcar todos' : 'Selecionar todos'}
+                      </button>
+                    )}
                   </div>
-                  <pre className="rounded-lg bg-[#1a202c] text-[#68d391] font-mono text-xs p-4 overflow-x-auto max-h-56 overflow-y-auto leading-relaxed whitespace-pre">
-                    {vba}
-                  </pre>
-                  <div className="mt-3 rounded-lg border-l-4 border-blue-400 bg-blue-500/10 px-4 py-3 text-xs text-blue-600 dark:text-blue-400 leading-relaxed">
-                    <p className="font-semibold mb-1">Como usar:</p>
-                    <ol className="list-decimal list-inside space-y-0.5">
-                      <li>Excel → <strong>Alt + F11</strong></li>
-                      <li><strong>Inserir → Módulo</strong></li>
-                      <li>Apague o código antigo e cole o novo</li>
-                      <li><strong>F5</strong> para executar</li>
-                    </ol>
+
+                  <div className="space-y-2 max-h-64 overflow-y-auto rounded-lg border border-border p-1">
+                    {pagamentos.map(p => {
+                      const temEmail = !!p.prestador_email
+                      const isChecked = selected.has(p.id)
+                      const descricao = formatDescricao(p)
+                      const valorFmt = p.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+
+                      return (
+                        <label
+                          key={p.id}
+                          className={`flex items-start gap-3 rounded-lg px-3 py-2.5 cursor-pointer transition-colors ${
+                            temEmail
+                              ? isChecked ? 'bg-primary/10 border border-primary/30' : 'hover:bg-muted border border-transparent'
+                              : 'opacity-40 cursor-not-allowed border border-transparent'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            disabled={!temEmail}
+                            onChange={() => toggle(p.id)}
+                            className="mt-0.5 h-4 w-4 rounded border-input accent-primary"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="text-sm font-medium text-foreground">{p.prestador_nome}</span>
+                              <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                p.tipo === 'comissao' ? 'bg-emerald-500/15 text-emerald-500' : 'bg-blue-500/15 text-blue-500'
+                              }`}>
+                                {p.tipo === 'comissao' ? 'Comissão' : 'Salário'}
+                              </span>
+                              <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} USDT</span>
+                            </div>
+                            <p className="text-xs text-muted-foreground mt-0.5 truncate">{descricao}</p>
+                            {temEmail && (
+                              <p className="text-xs text-muted-foreground/60 mt-0.5">{p.prestador_email}</p>
+                            )}
+                          </div>
+                        </label>
+                      )
+                    })}
                   </div>
                 </div>
-              )}
-            </div>
+
+                {/* Botão gerar */}
+                <button
+                  onClick={handleGerar}
+                  disabled={selected.size === 0 || isPending}
+                  className="w-full inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Code2 className="h-4 w-4" />}
+                  {isPending ? 'Registrando...' : `Gerar Script VBA (${selected.size} email${selected.size !== 1 ? 's' : ''})`}
+                </button>
+
+                {/* Output VBA */}
+                {vba && (
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <label className="text-sm font-medium text-foreground">Script VBA gerado</label>
+                      <button
+                        onClick={handleCopy}
+                        className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                          copied
+                            ? 'bg-emerald-500/15 text-emerald-500'
+                            : 'bg-muted text-muted-foreground hover:text-foreground'
+                        }`}
+                      >
+                        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                        {copied ? 'Copiado!' : 'Copiar'}
+                      </button>
+                    </div>
+                    <pre className="rounded-lg bg-[#1a202c] text-[#68d391] font-mono text-xs p-4 overflow-x-auto max-h-56 overflow-y-auto leading-relaxed whitespace-pre">
+                      {vba}
+                    </pre>
+                    <div className="mt-3 rounded-lg border-l-4 border-blue-400 bg-blue-500/10 px-4 py-3 text-xs text-blue-600 dark:text-blue-400 leading-relaxed">
+                      <p className="font-semibold mb-1">Como usar:</p>
+                      <ol className="list-decimal list-inside space-y-0.5">
+                        <li>Excel → <strong>Alt + F11</strong></li>
+                        <li><strong>Inserir → Módulo</strong></li>
+                        <li>Apague o código antigo e cole o novo</li>
+                        <li><strong>F5</strong> para executar</li>
+                      </ol>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── Step: Mailto ── */}
+            {step === 'mailto' && (
+              <div className="px-6 py-5 space-y-5">
+
+                {/* Estado vazio */}
+                {pagamentos.length === 0 && (
+                  <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
+                    Nenhum pagamento USDT com hash cadastrado neste mês.
+                  </div>
+                )}
+
+                {/* Aviso sem email */}
+                {semEmail.length > 0 && (
+                  <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                    <span>
+                      {semEmail.map(p => p.prestador_nome).join(', ')} não {semEmail.length === 1 ? 'possui' : 'possuem'} email cadastrado e {semEmail.length === 1 ? 'não pode' : 'não podem'} ser selecionado{semEmail.length === 1 ? '' : 's'}.
+                    </span>
+                  </div>
+                )}
+
+                {/* Lista de pagamentos */}
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <label className="text-sm font-medium text-foreground">
+                      Selecionar pagamentos ({selected.size} selecionado{selected.size !== 1 ? 's' : ''})
+                    </label>
+                    {elegíveis.length > 0 && (
+                      <button
+                        onClick={toggleAll}
+                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        {selected.size === elegíveis.length ? 'Desmarcar todos' : 'Selecionar todos'}
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="space-y-2 max-h-64 overflow-y-auto rounded-lg border border-border p-1">
+                    {pagamentos.map(p => {
+                      const temEmail = !!p.prestador_email
+                      const isChecked = selected.has(p.id)
+                      const descricao = formatDescricao(p)
+                      const valorFmt = p.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+
+                      return (
+                        <label
+                          key={p.id}
+                          className={`flex items-start gap-3 rounded-lg px-3 py-2.5 cursor-pointer transition-colors ${
+                            temEmail
+                              ? isChecked ? 'bg-primary/10 border border-primary/30' : 'hover:bg-muted border border-transparent'
+                              : 'opacity-40 cursor-not-allowed border border-transparent'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            disabled={!temEmail}
+                            onChange={() => toggle(p.id)}
+                            className="mt-0.5 h-4 w-4 rounded border-input accent-primary"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="text-sm font-medium text-foreground">{p.prestador_nome}</span>
+                              <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                p.tipo === 'comissao' ? 'bg-emerald-500/15 text-emerald-500' : 'bg-blue-500/15 text-blue-500'
+                              }`}>
+                                {p.tipo === 'comissao' ? 'Comissão' : 'Salário'}
+                              </span>
+                              <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} USDT</span>
+                            </div>
+                            <p className="text-xs text-muted-foreground mt-0.5 truncate">{descricao}</p>
+                            {temEmail && (
+                              <p className="text-xs text-muted-foreground/60 mt-0.5">{p.prestador_email}</p>
+                            )}
+                          </div>
+                        </label>
+                      )
+                    })}
+                  </div>
+                </div>
+
+                {/* Botão gerar links */}
+                <button
+                  onClick={handleAbrirEmails}
+                  disabled={selected.size === 0 || isPending}
+                  className="w-full inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ExternalLink className="h-4 w-4" />}
+                  {isPending ? 'Registrando...' : `Gerar links de email (${selected.size} email${selected.size !== 1 ? 's' : ''})`}
+                </button>
+
+                {/* Links gerados */}
+                {mailtoGerados.length > 0 && (
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Clique para abrir cada email no Outlook:
+                    </label>
+                    <div className="space-y-2">
+                      {mailtoGerados.map(item => (
+                        <a
+                          key={item.id}
+                          href={item.link}
+                          className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3 hover:border-primary/50 hover:bg-primary/5 transition-all group"
+                        >
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-foreground">{item.nome}</p>
+                            <p className="text-xs text-muted-foreground truncate">{item.email}</p>
+                          </div>
+                          <ExternalLink className="h-4 w-4 shrink-0 ml-3 text-muted-foreground group-hover:text-primary transition-colors" />
+                        </a>
+                      ))}
+                    </div>
+                    <div className="mt-3 rounded-lg border-l-4 border-blue-400 bg-blue-500/10 px-4 py-3 text-xs text-blue-600 dark:text-blue-400 leading-relaxed">
+                      <p className="font-semibold mb-1">Lembre-se:</p>
+                      <ol className="list-decimal list-inside space-y-0.5">
+                        <li>Clique em cada nome acima para abrir no Outlook</li>
+                        <li>Troque a caixa de envio para a conta correta</li>
+                        <li>Confirme e envie</li>
+                      </ol>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
           </div>
         </div>
       )}

--- a/src/app/historico/page.tsx
+++ b/src/app/historico/page.tsx
@@ -1,4 +1,6 @@
-﻿import Link from 'next/link'
+﻿export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
 import { ArrowLeft, CalendarDays } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import type { HistoricoPagamento, MoedaSimples } from '@/lib/types'
@@ -12,6 +14,7 @@ import EmailStatusEditor from './email-status-editor'
 import EmailVbaDialog from './email-vba-dialog'
 import type { HistoricoParaEmail } from './email-vba-dialog'
 import CollapsibleSection from './collapsible-section'
+import RefreshButton from './refresh-button'
 
 const MESES = [
   'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
@@ -168,6 +171,7 @@ export default async function HistoricoPage({
             </div>
           </div>
           <div className="flex items-center gap-3">
+            <RefreshButton />
             <EmailVbaDialog pagamentos={pagamentosEmail} />
             <MesSelector mesAtual={mesAtual} />
           </div>

--- a/src/app/historico/refresh-button.tsx
+++ b/src/app/historico/refresh-button.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+
+export default function RefreshButton() {
+  return (
+    <button
+      onClick={() => window.location.reload()}
+      title="Atualizar página"
+      className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+    >
+      <RefreshCw className="h-4 w-4" />
+      Atualizar
+    </button>
+  )
+}


### PR DESCRIPTION
# Envio de Email no Histórico de Pagamentos — Mailto

## Contexto

O sistema possuía um fluxo de envio de comprovantes via **VBA Script** (Excel + Outlook Clássico no Windows). Com a migração para MacBook, o Outlook Clássico não está disponível, tornando o fluxo VBA inoperante no Mac.

A solução adotada foi adicionar uma segunda opção de envio via **Mailto**, que funciona com qualquer cliente de email configurado no sistema operacional (Outlook Moderno, Apple Mail, etc.), sem necessidade de APIs externas ou cadastros adicionais.

---

## O que foi alterado

### `src/app/historico/email-vba-dialog.tsx`

Arquivo principal do fluxo de email. As mudanças adicionam uma camada de seleção de método sem remover nem alterar o fluxo VBA existente.

**Novas adições:**

- **Tipo `Step`** (`'method' | 'vba' | 'mailto'`): controla em qual etapa do dialog o usuário está.
- **Tela de seleção de método** (step `'method'`): ao abrir o dialog, o usuário vê dois cards — *VBA Script* e *Mailto* — com botão de voltar no header após a escolha.
- **Função `generateMailtoLink(p)`**: gera um link `mailto:` com destinatário, assunto (`Comprovante de Pagamento`) e corpo pré-preenchido (nome, descrição, valor em USDT e hash da transação), tudo URL-encoded.
- **Estado `mailtoGerados`**: lista de links gerados após clicar em "Gerar links de email".
- **Função `handleAbrirEmails()`**: gera os links mailto para os pagamentos selecionados, chama `marcarEmailsEnviados` no banco e dispara `router.refresh()` após a conclusão.
- **Step `'mailto'`**: UI idêntica ao fluxo VBA na seleção de pagamentos, mas sem campo de remetente. O botão "Gerar links de email" gera os links e exibe uma lista clicável — um item por prestador — que abre o cliente de email padrão com o email já montado.
- **`router.refresh()`** chamado dentro do `startTransition` após `await marcarEmailsEnviados`, garantindo que o banco já foi atualizado antes do refresh da página.

**Fluxo do usuário (Mailto):**

1. Clicar em **Enviar Email** → selecionar **Mailto**
2. Selecionar os pagamentos desejados (apenas USDT/USDC com hash e email pendente)
3. Clicar em **Gerar links de email**
4. Clicar em cada nome na lista gerada → Outlook abre com email pré-preenchido
5. Trocar a caixa de envio para a conta correta e confirmar o envio
6. Os pagamentos são marcados como `email_enviado = true` automaticamente

**Observação sobre remetente:** O protocolo `mailto:` não suporta definir o campo `From`. O usuário deve selecionar manualmente a caixa de envio correta no Outlook ao abrir cada email.

---

### `src/app/historico/page.tsx`

- Adicionado `export const dynamic = 'force-dynamic'` para desabilitar o cache do Next.js nesta rota, garantindo que os dados do banco sejam sempre buscados frescos.
- Adicionado o componente `<RefreshButton />` ao lado do botão "Enviar Email".

---

### `src/app/historico/refresh-button.tsx` *(novo)*

Componente cliente simples com um botão **Atualizar** que executa `window.location.reload()`. Permite ao usuário forçar a atualização dos status de email na página após o envio.

---

## Decisões técnicas

| Decisão | Motivo |
|---|---|
| Manter VBA + adicionar Mailto | VBA ainda funciona no Windows; não havia motivo para remover |
| `window.location.reload()` no botão Atualizar | `router.refresh()` do Next.js não estava invalidando o cache corretamente no ambiente local |
| `force-dynamic` na página | Evita que o Next.js sirva dados em cache após atualizações no banco |
| Sem campo de remetente no Mailto | `mailto:` não suporta `From`; o cliente de email usa a conta padrão configurada |
| Links clicáveis por prestador | Mais confiável que abrir múltiplas janelas via JavaScript, que pode ser bloqueado pelo browser |
| `marcarEmailsEnviados` chamado ao gerar links | Mesmo comportamento do VBA — marca como enviado no momento em que o usuário inicia o envio |
