### PR TITLE
feat: comprovante PIX como PDF anexado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# supabase local CLI artifacts
+supabase/.temp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^1.8.0",
         "next": "16.2.4",
         "react": "19.2.4",
@@ -3694,6 +3695,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5121,6 +5128,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5157,6 +5170,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5771,6 +5790,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5813,6 +5844,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6586,6 +6626,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6752,6 +6798,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6837,6 +6889,27 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/redent": {
@@ -7040,6 +7113,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -7152,6 +7231,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7359,6 +7444,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -8045,6 +8139,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/src/app/api/comprovantes/[id]/route.ts
+++ b/src/app/api/comprovantes/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return new NextResponse(null, { status: 401 })
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('organization_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.organization_id) return new NextResponse(null, { status: 403 })
+
+  const { data: pagamento } = await supabase
+    .from('historico_pagamentos')
+    .select('comprovante_arquivo, comprovante_arquivo_nome, organization_id')
+    .eq('id', id)
+    .eq('organization_id', profile.organization_id)
+    .single()
+
+  if (!pagamento || pagamento.organization_id !== profile.organization_id) {
+    return new NextResponse(null, { status: 403 })
+  }
+
+  if (!pagamento.comprovante_arquivo) return new NextResponse(null, { status: 404 })
+
+  const sp = request.nextUrl.searchParams
+  const baixar = sp.get('download') === '1'
+
+  // O fluxo de email (VBA) precisa de um nome previsível para anexar o arquivo do disco
+  const nomeArquivo = sp.get('nomefixo') === '1'
+    ? `comprovante-${id}.pdf`
+    : pagamento.comprovante_arquivo_nome ?? 'comprovante.pdf'
+
+  // Bucket privado: o download exige token assinado (service role)
+  const admin = createAdminClient()
+  const { data } = await admin.storage
+    .from('comprovantes')
+    .createSignedUrl(
+      pagamento.comprovante_arquivo,
+      60,
+      baixar ? { download: nomeArquivo } : undefined,
+    )
+
+  if (!data?.signedUrl) return new NextResponse(null, { status: 404 })
+
+  // O client pede ?json=1 para abrir a URL do Supabase direto numa aba nova.
+  // Navegar para esta rota (mesma origem) faz o Chrome capturar o link em PWAs instalados.
+  if (sp.get('json') === '1') {
+    return NextResponse.json({ url: data.signedUrl, nomeArquivo })
+  }
+
+  return NextResponse.redirect(data.signedUrl, { status: 307 })
+}

--- a/src/app/api/comprovantes/zip/route.ts
+++ b/src/app/api/comprovantes/zip/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import JSZip from 'jszip'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+function sanitizar(s: string) {
+  return s.replace(/[^a-zA-Z0-9À-ÿ._-]/g, '_').replace(/_+/g, '_')
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return new NextResponse(null, { status: 401 })
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('organization_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.organization_id) return new NextResponse(null, { status: 403 })
+
+  const sp = request.nextUrl.searchParams
+  const mes = sp.get('mes')            // 'YYYY-MM' (opcional)
+  const prestadorId = sp.get('prestador') // uuid (opcional)
+
+  if (mes && !/^\d{4}-(0[1-9]|1[0-2])$/.test(mes)) {
+    return NextResponse.json({ error: 'Mês inválido.' }, { status: 400 })
+  }
+
+  let query = supabase
+    .from('historico_pagamentos')
+    .select('id, prestador_nome, descricao, pago_em, mes_referencia, comprovante_arquivo, comprovante_arquivo_nome')
+    .eq('organization_id', profile.organization_id)
+    .not('comprovante_arquivo', 'is', null)
+
+  if (mes) query = query.eq('mes_referencia', `${mes}-01`)
+  if (prestadorId) query = query.eq('prestador_id', prestadorId)
+
+  const { data: pagamentos, error } = await query.order('pago_em', { ascending: false })
+
+  if (error) return NextResponse.json({ error: 'Erro ao buscar comprovantes.' }, { status: 500 })
+  if (!pagamentos || pagamentos.length === 0) {
+    return NextResponse.json({ error: 'Nenhum comprovante encontrado para esses filtros.' }, { status: 404 })
+  }
+
+  const admin = createAdminClient()
+  const zip = new JSZip()
+  const usados = new Set<string>()
+  let incluidos = 0
+
+  for (const p of pagamentos) {
+    if (!p.comprovante_arquivo) continue
+
+    const { data: arquivo } = await admin.storage
+      .from('comprovantes')
+      .download(p.comprovante_arquivo)
+
+    if (!arquivo) continue
+
+    // Nome legível: Prestador_AAAA-MM_id.pdf (id evita colisão entre pagamentos do mesmo mês)
+    const mesRef = (p.mes_referencia ?? '').substring(0, 7)
+    let nome = `${sanitizar(p.prestador_nome)}_${mesRef}_${p.id.slice(0, 8)}.pdf`
+    while (usados.has(nome)) nome = `${nome.replace(/\.pdf$/, '')}_1.pdf`
+    usados.add(nome)
+
+    zip.file(nome, await arquivo.arrayBuffer())
+    incluidos++
+  }
+
+  if (incluidos === 0) {
+    return NextResponse.json({ error: 'Não foi possível baixar os comprovantes.' }, { status: 404 })
+  }
+
+  const conteudo = await zip.generateAsync({ type: 'uint8array', compression: 'DEFLATE' })
+
+  const partes = ['comprovantes']
+  if (prestadorId) partes.push(sanitizar(pagamentos[0].prestador_nome))
+  if (mes) partes.push(mes)
+  const nomeZip = `${partes.join('_')}.zip`
+
+  return new NextResponse(conteudo as unknown as BodyInit, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${nomeZip}"`,
+      'Content-Length': String(conteudo.byteLength),
+    },
+  })
+}

--- a/src/app/api/export/[module]/route.ts
+++ b/src/app/api/export/[module]/route.ts
@@ -279,6 +279,7 @@ export async function GET(
         'Valor': p.valor,
         'Moeda': p.moeda,
         'Comprovante': p.comprovante ?? '',
+        'Comprovante PDF': p.comprovante_arquivo ? 'Sim' : 'Não',
         'Nota Fiscal': p.nota_fiscal ? 'Sim' : 'Não',
         'Mês Referência': p.mes_referencia,
       }))

--- a/src/app/comissoes/actions.ts
+++ b/src/app/comissoes/actions.ts
@@ -435,7 +435,7 @@ export async function registrarPagamentoComissao(input: RegistrarPagamentoInput)
 
   const descricao = `Comissão: ${input.tipo} — ${input.descricaoComissao}`
 
-  const { error: errHistorico } = await supabase
+  const { data, error: errHistorico } = await supabase
     .from('historico_pagamentos')
     .insert({
       tipo: 'comissao',
@@ -451,8 +451,11 @@ export async function registrarPagamentoComissao(input: RegistrarPagamentoInput)
       mes_referencia: input.mesReferencia,
       organization_id: orgId,
     })
+    .select('id')
+    .single()
 
   if (errHistorico) throw new Error('Erro ao registrar pagamento.')
+  const historicoId = data.id
 
   const { error: errUpdate } = await supabase
     .from('comissao_prestadores')
@@ -480,4 +483,6 @@ export async function registrarPagamentoComissao(input: RegistrarPagamentoInput)
 
   revalidatePath('/comissoes')
   revalidatePath('/historico')
+
+  return { historicoId }
 }

--- a/src/app/comissoes/comissoes-list.tsx
+++ b/src/app/comissoes/comissoes-list.tsx
@@ -5,6 +5,7 @@ import { Plus, Pencil, Trash2, Loader2, Percent, Wallet, QrCode, CheckCircle2, C
 import type { Comissao, PrestadorResumido, MoedaSimples, TipoChavePix } from '@/lib/types'
 import { TIPO_PIX_LABEL } from '@/lib/types'
 import { useExchangeRate } from '@/hooks/use-exchange-rate'
+import AbrirComprovanteButton from '@/components/abrir-comprovante-button'
 import { excluirComissao, atualizarNotaFiscalComissao, encerrarRecorrencia, gerarInstanciaAgora } from './actions'
 import ComissaoFormDialog from './comissao-form-dialog'
 import RegistrarPagamentoDialog, { type PagamentoContext } from './registrar-pagamento-dialog'
@@ -194,9 +195,11 @@ function TemplateCard({
 export default function ComissoesList({
   comissoes,
   prestadoresAtivos,
+  historicoPorCp = {},
 }: {
   comissoes: Comissao[]
   prestadoresAtivos: PrestadorResumido[]
+  historicoPorCp?: Record<string, { id: string; comprovante_arquivo: string | null }>
 }) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingComissao, setEditingComissao] = useState<Comissao | null>(null)
@@ -642,10 +645,18 @@ export default function ComissoesList({
                           )}
 
                           {cp.pago ? (
-                            <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/15 px-2.5 py-1 text-xs font-medium text-emerald-300">
-                              <CheckCircle2 className="h-3 w-3" />
-                              Pago
-                            </span>
+                            <>
+                              {historicoPorCp[cp.id]?.comprovante_arquivo && (
+                                <AbrirComprovanteButton
+                                  historicoId={historicoPorCp[cp.id].id}
+                                  className="inline-flex items-center gap-1 rounded-lg border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-xs font-medium text-blue-400 hover:bg-blue-500/20 hover:border-blue-500/50 transition-colors disabled:opacity-50"
+                                />
+                              )}
+                              <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/15 px-2.5 py-1 text-xs font-medium text-emerald-300">
+                                <CheckCircle2 className="h-3 w-3" />
+                                Pago
+                              </span>
+                            </>
                           ) : (
                             <button
                               onClick={() => setPagamentoContext({

--- a/src/app/comissoes/page.tsx
+++ b/src/app/comissoes/page.tsx
@@ -12,7 +12,7 @@ export default async function ComissoesPage() {
   const supabase = await createClient()
   const orgId = await getOrganizationId()
 
-  const [comissoesRes, prestadoresRes] = await Promise.all([
+  const [comissoesRes, prestadoresRes, historicoRes] = await Promise.all([
     supabase
       .from('comissoes')
       .select(`
@@ -29,9 +29,25 @@ export default async function ComissoesPage() {
       .select('id, nome, ativo, carteira_cripto, rede_cripto, cripto_moeda, chave_pix, tipo_chave_pix')
       .eq('organization_id', orgId)
       .order('nome'),
+    supabase
+      .from('historico_pagamentos')
+      .select('id, comissao_prestador_id, comprovante_arquivo')
+      .eq('organization_id', orgId)
+      .not('comissao_prestador_id', 'is', null),
   ])
 
-  const error = comissoesRes.error || prestadoresRes.error
+  const error = comissoesRes.error || prestadoresRes.error || historicoRes.error
+
+  // Mapeia cada comissao_prestador pago ao seu histórico (para o link do PDF)
+  const historicoPorCp: Record<string, { id: string; comprovante_arquivo: string | null }> = {}
+  for (const h of historicoRes.data ?? []) {
+    if (h.comissao_prestador_id && !historicoPorCp[h.comissao_prestador_id]) {
+      historicoPorCp[h.comissao_prestador_id] = {
+        id: h.id,
+        comprovante_arquivo: h.comprovante_arquivo,
+      }
+    }
+  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -70,6 +86,7 @@ export default async function ComissoesPage() {
           <ComissoesList
             comissoes={comissoesRes.data ?? []}
             prestadoresAtivos={prestadoresRes.data ?? []}
+            historicoPorCp={historicoPorCp}
           />
         )}
       </main>

--- a/src/app/comissoes/registrar-pagamento-dialog.tsx
+++ b/src/app/comissoes/registrar-pagamento-dialog.tsx
@@ -6,6 +6,8 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { X, Loader2, Wallet, QrCode, ChevronLeft, ChevronRight } from 'lucide-react'
 import { registrarPagamentoComissao } from './actions'
+import { atualizarComprovanteArquivo } from '../historico/actions'
+import ArquivoComprovanteField from '@/components/arquivo-comprovante-field'
 import type { MoedaSimples } from '@/lib/types'
 
 export interface PagamentoContext {
@@ -59,6 +61,7 @@ export default function RegistrarPagamentoDialog({ context, onClose }: Props) {
   const [selectedMes, setSelectedMes] = useState(getMesAtual())
   const [isPending, startTransition] = useTransition()
   const [serverError, setServerError] = useState<string | null>(null)
+  const [arquivo, setArquivo] = useState<File | null>(null)
 
   const form = useForm<FormData>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -76,6 +79,7 @@ export default function RegistrarPagamentoDialog({ context, onClose }: Props) {
     })
     setSelectedMes(context.defaultMes)
     setServerError(null)
+    setArquivo(null)
   }, [context, form])
 
   function navegarMes(delta: number) {
@@ -93,7 +97,7 @@ export default function RegistrarPagamentoDialog({ context, onClose }: Props) {
 
     startTransition(async () => {
       try {
-        await registrarPagamentoComissao({
+        const { historicoId } = await registrarPagamentoComissao({
           cpId: context.cpId,
           comissaoId: context.comissaoId,
           prestadorId: context.prestadorId,
@@ -106,6 +110,11 @@ export default function RegistrarPagamentoDialog({ context, onClose }: Props) {
           mesReferencia: `${selectedMes}-01`,
           notaFiscal: context.notaFiscal,
         })
+        if (arquivo) {
+          const fd = new FormData()
+          fd.append('arquivo', arquivo)
+          await atualizarComprovanteArquivo(historicoId, fd)
+        }
         onClose()
       } catch (e) {
         setServerError(e instanceof Error ? e.message : 'Erro ao registrar pagamento.')
@@ -224,17 +233,40 @@ export default function RegistrarPagamentoDialog({ context, onClose }: Props) {
               </div>
 
               {/* Hash / Comprovante */}
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1.5">
-                  {isUsdt ? 'Hash da transação' : 'Comprovante PIX'}{' '}
-                  <span className="text-muted-foreground font-normal">(opcional)</span>
-                </label>
-                <input
-                  {...form.register('comprovante')}
-                  type="text"
-                  placeholder={isUsdt ? '0x...' : 'ID ou descrição do comprovante'}
-                  className={inputClass + ' font-mono'}
-                />
+              <div className="space-y-3">
+                {(isUsdt ? (
+                  <>
+                    <label className="block text-sm font-medium text-foreground mb-1.5">
+                      Hash da transação <span className="text-muted-foreground font-normal">(opcional)</span>
+                    </label>
+                    <input
+                      {...form.register('comprovante')}
+                      type="text"
+                      placeholder="0x..."
+                      className={inputClass + ' font-mono'}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1.5">
+                        Comprovante PIX (PDF) <span className="text-muted-foreground font-normal">(opcional)</span>
+                      </label>
+                      <ArquivoComprovanteField onArquivo={setArquivo} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1.5">
+                        ID ou descrição <span className="text-muted-foreground font-normal">(opcional)</span>
+                      </label>
+                      <input
+                        {...form.register('comprovante')}
+                        type="text"
+                        placeholder="ID ou descrição do comprovante"
+                        className={inputClass + ' font-mono'}
+                      />
+                    </div>
+                  </>
+                ))}
               </div>
 
               {serverError && (

--- a/src/app/historico/actions.ts
+++ b/src/app/historico/actions.ts
@@ -1,8 +1,22 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { randomUUID } from 'crypto'
 import { createClient } from '@/lib/supabase/server'
 import { getOrganizationId } from '@/lib/auth'
+
+const BUCKET = 'comprovantes'
+const MAX_PDF_BYTES = 5 * 1024 * 1024
+
+function sanitizarNomeArquivo(nome: string): string {
+  const base = nome.replace(/\.pdf$/i, '')
+  const limpo = base.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80)
+  return `${limpo || 'comprovante'}.pdf`
+}
+
+function objectPath(orgId: string, historicoId: string, nome: string) {
+  return `${orgId}/${historicoId}/${randomUUID()}-${sanitizarNomeArquivo(nome)}`
+}
 
 export async function atualizarNotaFiscalHistorico(id: string, notaFiscal: boolean) {
   const orgId = await getOrganizationId()
@@ -49,6 +63,85 @@ export async function atualizarComprovante(id: string, comprovante: string) {
     .eq('id', id)
     .eq('organization_id', orgId)
   if (error) throw new Error('Erro ao atualizar comprovante.')
+  revalidatePath('/historico')
+}
+
+export async function atualizarComprovanteArquivo(id: string, formData: FormData) {
+  const file = formData.get('arquivo')
+  if (!(file instanceof File)) throw new Error('Nenhum arquivo enviado.')
+  if (file.type !== 'application/pdf') throw new Error('Apenas arquivos PDF são aceitos.')
+  if (file.size > MAX_PDF_BYTES) throw new Error('O PDF deve ter no máximo 5 MB.')
+
+  const bytes = await file.arrayBuffer()
+
+  const orgId = await getOrganizationId()
+  const supabase = await createClient()
+
+  // Busca a linha e o arquivo atual (se houver) para substituir
+  const { data: atual, error: errGet } = await supabase
+    .from('historico_pagamentos')
+    .select('id, comprovante_arquivo, organization_id')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .single()
+  if (errGet || !atual) throw new Error('Pagamento não encontrado.')
+
+  const path = objectPath(orgId, atual.id, file.name)
+
+  const { error: errUpload } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, bytes, { contentType: 'application/pdf', upsert: false })
+  if (errUpload) throw new Error('Erro ao enviar o arquivo.')
+
+  const { error: errUpdate } = await supabase
+    .from('historico_pagamentos')
+    .update({
+      comprovante_arquivo: path,
+      comprovante_arquivo_nome: file.name,
+      comprovante_arquivo_tamanho: file.size,
+    })
+    .eq('id', atual.id)
+    .eq('organization_id', orgId)
+  if (errUpdate) {
+    await supabase.storage.from(BUCKET).remove([path])
+    throw new Error('Erro ao salvar o comprovante.')
+  }
+
+  // Remove o arquivo anterior após o novo estar salvo
+  if (atual.comprovante_arquivo && atual.comprovante_arquivo !== path) {
+    await supabase.storage.from(BUCKET).remove([atual.comprovante_arquivo])
+  }
+
+  revalidatePath('/historico')
+}
+
+export async function removerComprovanteArquivo(id: string) {
+  const orgId = await getOrganizationId()
+  const supabase = await createClient()
+
+  const { data: atual, error: errGet } = await supabase
+    .from('historico_pagamentos')
+    .select('id, comprovante_arquivo, organization_id')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .single()
+  if (errGet || !atual) throw new Error('Pagamento não encontrado.')
+
+  if (atual.comprovante_arquivo) {
+    await supabase.storage.from(BUCKET).remove([atual.comprovante_arquivo])
+  }
+
+  const { error } = await supabase
+    .from('historico_pagamentos')
+    .update({
+      comprovante_arquivo: null,
+      comprovante_arquivo_nome: null,
+      comprovante_arquivo_tamanho: null,
+    })
+    .eq('id', atual.id)
+    .eq('organization_id', orgId)
+  if (error) throw new Error('Erro ao remover o comprovante.')
+
   revalidatePath('/historico')
 }
 

--- a/src/app/historico/baixar-pdfs-dialog.tsx
+++ b/src/app/historico/baixar-pdfs-dialog.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useState } from 'react'
+import { FileArchive, X, Loader2, Download, AlertTriangle } from 'lucide-react'
+
+const MESES = [
+  'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+  'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+]
+
+function formatMes(yyyyMm: string) {
+  const [ano, mes] = yyyyMm.split('-').map(Number)
+  return `${MESES[mes - 1]} ${ano}`
+}
+
+interface Props {
+  mesAtual: string
+  prestadores: { id: string; nome: string }[]
+  meses: string[]
+}
+
+export default function BaixarPdfsDialog({ mesAtual, prestadores, meses }: Props) {
+  const [open, setOpen] = useState(false)
+  const [mes, setMes] = useState<string>(mesAtual)
+  const [prestador, setPrestador] = useState<string>('')
+  const [baixando, setBaixando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
+  function handleOpen() {
+    setMes(mesAtual)
+    setPrestador('')
+    setErro(null)
+    setOpen(true)
+  }
+
+  async function handleBaixar() {
+    setBaixando(true)
+    setErro(null)
+    try {
+      const qs = new URLSearchParams()
+      if (mes) qs.set('mes', mes)
+      if (prestador) qs.set('prestador', prestador)
+
+      const res = await fetch(`/api/comprovantes/zip?${qs.toString()}`)
+      if (!res.ok) {
+        const msg = await res.json().catch(() => null)
+        throw new Error(msg?.error ?? 'Não foi possível gerar o arquivo.')
+      }
+
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      const match = res.headers.get('Content-Disposition')?.match(/filename="([^"]+)"/)
+      a.download = match?.[1] ?? 'comprovantes.zip'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+      setOpen(false)
+    } catch (e) {
+      setErro(e instanceof Error ? e.message : 'Não foi possível gerar o arquivo.')
+    } finally {
+      setBaixando(false)
+    }
+  }
+
+  const selectClass =
+    'w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring'
+
+  const resumo = [
+    prestador ? prestadores.find(p => p.id === prestador)?.nome : 'Todos os prestadores',
+    mes ? formatMes(mes) : 'Todos os meses',
+  ].join(' · ')
+
+  return (
+    <>
+      <button
+        onClick={handleOpen}
+        title="Baixar comprovantes em PDF"
+        className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+      >
+        <FileArchive className="h-4 w-4" />
+        Baixar PDF&apos;s
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/60" onClick={() => !baixando && setOpen(false)} />
+          <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-background shadow-2xl">
+
+            <div className="flex items-center justify-between px-6 py-5 border-b border-border">
+              <div className="flex items-center gap-2">
+                <FileArchive className="h-5 w-5 text-muted-foreground" />
+                <h2 className="text-base font-semibold text-foreground">Baixar comprovantes</h2>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                disabled={baixando}
+                className="rounded-lg p-1.5 text-muted-foreground hover:bg-muted transition-colors disabled:opacity-40"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="px-6 py-5 space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Os comprovantes em PDF serão baixados em uma pasta compactada (.zip).
+                Combine os filtros para restringir o resultado.
+              </p>
+
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1.5">Mês</label>
+                <select value={mes} onChange={e => setMes(e.target.value)} className={selectClass}>
+                  <option value="">Todos os meses</option>
+                  {meses.map(m => (
+                    <option key={m} value={m}>{formatMes(m)}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1.5">Prestador</label>
+                <select
+                  value={prestador}
+                  onChange={e => setPrestador(e.target.value)}
+                  className={selectClass}
+                >
+                  <option value="">Todos os prestadores</option>
+                  {prestadores.map(p => (
+                    <option key={p.id} value={p.id}>{p.nome}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="rounded-lg bg-muted/50 px-3 py-2">
+                <p className="text-xs text-muted-foreground">
+                  Baixando: <span className="font-medium text-foreground">{resumo}</span>
+                </p>
+              </div>
+
+              {erro && (
+                <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                  <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                  <span>{erro}</span>
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-border px-6 py-4">
+              <button
+                onClick={() => setOpen(false)}
+                disabled={baixando}
+                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-40"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleBaixar}
+                disabled={baixando}
+                className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+              >
+                {baixando ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                {baixando ? 'Gerando .zip...' : 'Baixar .zip'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/app/historico/comprovante-editor.tsx
+++ b/src/app/historico/comprovante-editor.tsx
@@ -1,21 +1,36 @@
-﻿'use client'
+'use client'
 
-import { useState, useTransition } from 'react'
-import { Pencil, Check, X, Hash, QrCode, Plus, Loader2 } from 'lucide-react'
-import { atualizarComprovante } from './actions'
+import { useRef, useState, useTransition } from 'react'
+import { Pencil, Check, X, Hash, QrCode, Plus, Loader2, Download, Trash2 } from 'lucide-react'
+import { atualizarComprovante, atualizarComprovanteArquivo, removerComprovanteArquivo } from './actions'
+import AbrirComprovanteButton from '@/components/abrir-comprovante-button'
 import type { MoedaSimples } from '@/lib/types'
 
 interface Props {
   id: string
   comprovante: string | null
+  comprovanteArquivo: string | null
+  comprovanteArquivoNome: string | null
   moeda: MoedaSimples
 }
 
-export default function ComprovanteEditor({ id, comprovante, moeda }: Props) {
+export default function ComprovanteEditor({
+  id,
+  comprovante,
+  comprovanteArquivo,
+  comprovanteArquivoNome,
+  moeda,
+}: Props) {
   const [displayed, setDisplayed] = useState<string | null>(comprovante)
   const [editValue, setEditValue] = useState(comprovante ?? '')
   const [editing, setEditing] = useState(false)
+  const [hasArquivo, setHasArquivo] = useState(!!comprovanteArquivo)
+  const [arquivoNome, setArquivoNome] = useState<string | null>(comprovanteArquivoNome)
+  const [uploading, setUploading] = useState(false)
+  const [removendo, setRemovendo] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const isUsdt = moeda !== 'BRL'
 
   function handleSave() {
@@ -31,66 +46,146 @@ export default function ComprovanteEditor({ id, comprovante, moeda }: Props) {
     setEditing(false)
   }
 
-  if (editing) {
-    return (
-      <div className="flex items-center gap-2">
-        <input
-          autoFocus
-          value={editValue}
-          onChange={e => setEditValue(e.target.value)}
-          onKeyDown={e => {
-            if (e.key === 'Enter') handleSave()
-            if (e.key === 'Escape') handleCancel()
-          }}
-          placeholder={isUsdt ? 'Hash da transação...' : 'Comprovante PIX...'}
-          className="flex-1 rounded border border-input bg-background px-2 py-1 font-mono text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-        />
-        <button
-          onClick={handleSave}
-          disabled={isPending || !editValue.trim()}
-          className="rounded p-1 text-emerald-400 hover:bg-emerald-500/100/10 disabled:opacity-40 transition-colors"
-          title="Salvar"
-        >
-          {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-        </button>
-        <button
-          onClick={handleCancel}
-          className="rounded p-1 text-muted-foreground hover:bg-muted transition-colors"
-          title="Cancelar"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-      </div>
-    )
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (file.type !== 'application/pdf') {
+      setErro('Apenas arquivos PDF são aceitos.')
+      return
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setErro('O PDF deve ter no máximo 5 MB.')
+      return
+    }
+    setErro(null)
+    setUploading(true)
+    try {
+      const fd = new FormData()
+      fd.append('arquivo', file)
+      await atualizarComprovanteArquivo(id, fd)
+      setHasArquivo(true)
+      setArquivoNome(file.name)
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Erro ao enviar o comprovante.')
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
   }
 
-  if (displayed) {
-    return (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        {isUsdt ? (
-          <Hash className="h-3.5 w-3.5 shrink-0" />
-        ) : (
-          <QrCode className="h-3.5 w-3.5 shrink-0" />
-        )}
-        <span className="font-mono break-all">{displayed}</span>
-        <button
-          onClick={() => { setEditValue(displayed); setEditing(true) }}
-          className="shrink-0 rounded p-0.5 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-          title="Editar"
-        >
-          <Pencil className="h-3 w-3" />
-        </button>
-      </div>
-    )
+  async function handleRemover() {
+    setRemovendo(true)
+    setErro(null)
+    try {
+      await removerComprovanteArquivo(id)
+      setHasArquivo(false)
+      setArquivoNome(null)
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Erro ao remover o comprovante.')
+    } finally {
+      setRemovendo(false)
+    }
   }
 
   return (
-    <button
-      onClick={() => setEditing(true)}
-      className="flex items-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
-    >
-      <Plus className="h-3.5 w-3.5" />
-      {isUsdt ? 'Adicionar hash' : 'Adicionar comprovante'}
-    </button>
+    <div className="space-y-1.5">
+      {/* Campo texto: hash (USDT) ou ID/descrição (BRL) */}
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            autoFocus
+            value={editValue}
+            onChange={e => setEditValue(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleSave()
+              if (e.key === 'Escape') handleCancel()
+            }}
+            placeholder={isUsdt ? 'Hash da transação...' : 'ID ou descrição...'}
+            className="flex-1 rounded border border-input bg-background px-2 py-1 font-mono text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <button
+            onClick={handleSave}
+            disabled={isPending}
+            className="rounded p-1 text-emerald-400 hover:bg-emerald-500/10 disabled:opacity-40 transition-colors"
+            title="Salvar"
+          >
+            {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+          </button>
+          <button
+            onClick={handleCancel}
+            className="rounded p-1 text-muted-foreground hover:bg-muted transition-colors"
+            title="Cancelar"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ) : displayed ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {isUsdt ? (
+            <Hash className="h-3.5 w-3.5 shrink-0" />
+          ) : (
+            <QrCode className="h-3.5 w-3.5 shrink-0" />
+          )}
+          <span className="font-mono break-all">{displayed}</span>
+          <button
+            onClick={() => { setEditValue(displayed); setEditing(true) }}
+            className="shrink-0 rounded p-0.5 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+            title="Editar"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setEditing(true)}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {isUsdt ? 'Adicionar hash' : 'Adicionar ID/descrição'}
+        </button>
+      )}
+
+      {/* Arquivo PDF (apenas BRL) */}
+      {!isUsdt && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {hasArquivo ? (
+            <>
+              <AbrirComprovanteButton
+                historicoId={id}
+                label={arquivoNome ?? 'Comprovante PDF'}
+                className="inline-flex items-center gap-1 rounded border border-input px-2 py-0.5 text-xs text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 transition-colors disabled:opacity-50"
+              />
+              <button
+                onClick={handleRemover}
+                disabled={removendo}
+                className="inline-flex items-center gap-1 rounded p-0.5 text-xs text-muted-foreground/60 hover:text-destructive transition-colors disabled:opacity-40"
+                title="Remover comprovante"
+              >
+                {removendo ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="inline-flex items-center gap-1.5 rounded border border-dashed border-input px-2 py-0.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors disabled:opacity-50"
+              >
+                {uploading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+                {uploading ? 'Enviando...' : 'Anexar comprovante (PDF)'}
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/pdf,.pdf"
+                className="hidden"
+                onChange={handleFile}
+              />
+            </>
+          )}
+          {erro && <span className="text-xs text-destructive">{erro}</span>}
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/app/historico/email-vba-dialog.tsx
+++ b/src/app/historico/email-vba-dialog.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useTransition, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Mail, X, Copy, Check, Code2, AlertTriangle, Loader2, ChevronLeft, ExternalLink } from 'lucide-react'
+import { Mail, X, Copy, Check, Code2, AlertTriangle, Loader2, ChevronLeft, ExternalLink, Download, Paperclip } from 'lucide-react'
 import { marcarEmailsEnviados } from './actions'
+import type { MoedaSimples } from '@/lib/types'
 
 type Step = 'method' | 'vba' | 'mailto'
 
@@ -37,7 +38,9 @@ export interface HistoricoParaEmail {
   prestador_email: string | null
   descricao: string
   valor: number
-  comprovante: string
+  moeda: MoedaSimples
+  comprovante: string | null
+  comprovante_arquivo: string | null
   mes_referencia: string
 }
 
@@ -59,6 +62,26 @@ function toVBAString(text: string) {
   return text.split('\n').map(l => `"${esc(l)}"`).join(` & vbCrLf & _\n${pad}`)
 }
 
+function temPdf(r: HistoricoParaEmail): boolean {
+  return !!r.comprovante_arquivo
+}
+
+// Nome com que o PDF é baixado — precisa bater com o ?nomefixo=1 da API
+function nomeArquivoPdf(r: HistoricoParaEmail): string {
+  return `comprovante-${r.id}.pdf`
+}
+
+function anexoLinha(r: HistoricoParaEmail, comAnexo = true): string {
+  if (r.moeda !== 'BRL' && r.comprovante) {
+    return `HASH: ${r.comprovante}`
+  }
+  // No mailto o arquivo não vai anexado, então não prometemos anexo no corpo
+  if (temPdf(r) && comAnexo) {
+    return 'Comprovante em anexo.'
+  }
+  return ''
+}
+
 function generateVBA(sender: string, rows: HistoricoParaEmail[]): string {
   const last = rows.length - 1
   let assignments = ''
@@ -66,43 +89,72 @@ function generateVBA(sender: string, rows: HistoricoParaEmail[]): string {
   rows.forEach((r, i) => {
     const descricao = formatDescricao(r)
     const valorFmt = r.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+    const anexo = anexoLinha(r)
     const body = [
       `Olá, ${r.prestador_nome}!`,
       '',
       `Segue o comprovante referente ao pagamento abaixo:`,
       '',
       descricao,
-      `Valor: ${valorFmt} USDT`,
-      `HASH: ${r.comprovante}`,
+      `Valor: ${valorFmt} ${r.moeda}`,
+      ...(anexo ? [anexo] : []),
       '',
       'Atenciosamente,',
     ].join('\n')
 
     assignments += `    arrEmail(${i}) = "${esc(r.prestador_email ?? '')}"\n`
     assignments += `    arrBody(${i})  = ${toVBAString(body)}\n`
+    assignments += `    arrAnexo(${i}) = "${temPdf(r) ? esc(nomeArquivoPdf(r)) : ''}"\n`
   })
 
   const sentOnBehalf = sender ? `            .SentOnBehalfOfName = "${esc(sender)}"\n` : ''
   const bcc = sender ? `            .BCC = "${esc(sender)}"\n` : ''
+  const totalAnexos = rows.filter(temPdf).length
 
   return `Sub EnviarComprovantes()
     Dim objOutlook  As Object
     Dim objMail     As Object
     Dim sBody       As String
     Dim sAssinatura As String
+    Dim sPasta      As String
+    Dim sCaminho    As String
     Dim i           As Integer
     Dim tentativas  As Integer
+    Dim faltando    As String
     Dim arrEmail(${last}) As String
     Dim arrBody(${last})  As String
+    Dim arrAnexo(${last}) As String
+
+    ' Pasta onde estão os ${totalAnexos} PDF(s) baixados pelo sistema.
+    ' Por padrão a pasta de Downloads do usuário — ajuste se você salvou em outro lugar.
+    sPasta = Environ("USERPROFILE") & "\\Downloads\\"
 
 ${assignments}
+    ' Confere se todos os anexos existem ANTES de enviar qualquer email
+    For i = 0 To ${last}
+        If arrAnexo(i) <> "" Then
+            If Dir(sPasta & arrAnexo(i)) = "" Then
+                faltando = faltando & vbCrLf & arrAnexo(i)
+            End If
+        End If
+    Next i
+    If faltando <> "" Then
+        MsgBox "Os PDFs abaixo nao foram encontrados em " & sPasta & ":" & faltando & _
+               vbCrLf & vbCrLf & "Baixe os comprovantes pelo sistema e rode de novo.", vbCritical
+        Exit Sub
+    End If
+
     Set objOutlook = CreateObject("Outlook.Application")
     For i = 0 To ${last}
         Set objMail = objOutlook.CreateItem(0)
         With objMail
             .To = arrEmail(i)
             .Subject = "Comprovante de Pagamento"
-${sentOnBehalf}${bcc}            .Display
+${sentOnBehalf}${bcc}            If arrAnexo(i) <> "" Then
+                sCaminho = sPasta & arrAnexo(i)
+                .Attachments.Add sCaminho
+            End If
+            .Display
             ' Aguarda assinatura carregar (loop de até 10s)
             tentativas = 0
             Do While Len(.HTMLBody) < 50 And tentativas < 20
@@ -128,14 +180,15 @@ End Sub`
 function generateMailtoLink(p: HistoricoParaEmail): string {
   const descricao = formatDescricao(p)
   const valorFmt = p.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+  const anexo = anexoLinha(p, false)
   const body = [
     `Olá, ${p.prestador_nome}!`,
     '',
     'Segue o comprovante referente ao pagamento abaixo:',
     '',
     descricao,
-    `Valor: ${valorFmt} USDT`,
-    `HASH: ${p.comprovante}`,
+    `Valor: ${valorFmt} ${p.moeda}`,
+    ...(anexo ? [anexo] : []),
     '',
     'Atenciosamente,',
   ].join('\n')
@@ -164,6 +217,8 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
   const [copied, setCopied] = useState(false)
   const [mailtoGerados, setMailtoGerados] = useState<MailtoItem[]>([])
   const [isPending, startTransition] = useTransition()
+  const [baixandoPdfs, setBaixandoPdfs] = useState(false)
+  const [pdfsBaixados, setPdfsBaixados] = useState(false)
 
   useEffect(() => {
     setSavedEmails(loadSavedEmails())
@@ -180,6 +235,7 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
     })
     setVba('')
     setMailtoGerados([])
+    setPdfsBaixados(false)
   }
 
   function toggleAll() {
@@ -190,6 +246,31 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
     }
     setVba('')
     setMailtoGerados([])
+    setPdfsBaixados(false)
+  }
+
+  // Baixa os PDFs com nome fixo (comprovante-{id}.pdf) para o VBA anexá-los do disco
+  async function handleBaixarPdfs() {
+    const rows = pagamentos.filter(p => selected.has(p.id) && temPdf(p))
+    setBaixandoPdfs(true)
+    try {
+      for (const p of rows) {
+        const res = await fetch(`/api/comprovantes/${p.id}?json=1&download=1&nomefixo=1`)
+        if (!res.ok) continue
+        const { url } = await res.json()
+        const a = document.createElement('a')
+        a.href = url
+        a.download = nomeArquivoPdf(p)
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+        // Espaça os downloads para o browser não bloquear em lote
+        await new Promise(r => setTimeout(r, 400))
+      }
+      setPdfsBaixados(true)
+    } finally {
+      setBaixandoPdfs(false)
+    }
   }
 
   function handleGerar() {
@@ -305,7 +386,7 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
 
                 {pagamentos.length === 0 ? (
                   <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
-                    Nenhum pagamento USDT com hash cadastrado neste mês.
+                    Nenhum pagamento com comprovante cadastrado neste mês.
                   </div>
                 ) : (
                   <div className="grid grid-cols-2 gap-4">
@@ -388,7 +469,7 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
                 {/* Estado vazio */}
                 {pagamentos.length === 0 && (
                   <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
-                    Nenhum pagamento USDT com hash cadastrado neste mês.
+                    Nenhum pagamento com comprovante cadastrado neste mês.
                   </div>
                 )}
 
@@ -449,7 +530,16 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
                               }`}>
                                 {p.tipo === 'comissao' ? 'Comissão' : 'Salário'}
                               </span>
-                              <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} USDT</span>
+                              <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} {p.moeda}</span>
+                              {temPdf(p) && (
+                                <span
+                                  title="Comprovante PDF será anexado"
+                                  className="inline-flex items-center gap-1 rounded-full bg-blue-500/15 px-2 py-0.5 text-xs font-medium text-blue-400"
+                                >
+                                  <Paperclip className="h-3 w-3" />
+                                  PDF
+                                </span>
+                              )}
                             </div>
                             <p className="text-xs text-muted-foreground mt-0.5 truncate">{descricao}</p>
                             {temEmail && (
@@ -461,6 +551,37 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
                     })}
                   </div>
                 </div>
+
+                {/* Passo 1: baixar os PDFs que o VBA vai anexar */}
+                {(() => {
+                  const comPdf = pagamentos.filter(p => selected.has(p.id) && temPdf(p))
+                  if (comPdf.length === 0) return null
+                  return (
+                    <div className="rounded-lg border border-border bg-muted/40 px-4 py-3 space-y-2">
+                      <p className="text-xs text-muted-foreground">
+                        <span className="font-medium text-foreground">{comPdf.length}</span> comprovante{comPdf.length !== 1 ? 's' : ''} em PDF
+                        {' '}ser{comPdf.length !== 1 ? 'ão' : 'á'} anexado{comPdf.length !== 1 ? 's' : ''} pelo script.
+                        Baixe {comPdf.length !== 1 ? 'os arquivos' : 'o arquivo'} antes de executar o VBA.
+                      </p>
+                      <button
+                        onClick={handleBaixarPdfs}
+                        disabled={baixandoPdfs}
+                        className={`w-full inline-flex items-center justify-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+                          pdfsBaixados
+                            ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-500'
+                            : 'border-border bg-card text-foreground hover:bg-muted'
+                        }`}
+                      >
+                        {baixandoPdfs
+                          ? <Loader2 className="h-4 w-4 animate-spin" />
+                          : pdfsBaixados ? <Check className="h-4 w-4" /> : <Download className="h-4 w-4" />}
+                        {baixandoPdfs
+                          ? 'Baixando PDFs...'
+                          : pdfsBaixados ? 'PDFs baixados' : `Baixar ${comPdf.length} PDF${comPdf.length !== 1 ? 's' : ''}`}
+                      </button>
+                    </div>
+                  )
+                })()}
 
                 {/* Botão gerar */}
                 <button
@@ -495,11 +616,15 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
                     <div className="mt-3 rounded-lg border-l-4 border-blue-400 bg-blue-500/10 px-4 py-3 text-xs text-blue-600 dark:text-blue-400 leading-relaxed">
                       <p className="font-semibold mb-1">Como usar:</p>
                       <ol className="list-decimal list-inside space-y-0.5">
+                        <li>Baixe os PDFs no botão acima (ficam em <strong>Downloads</strong>)</li>
                         <li>Excel → <strong>Alt + F11</strong></li>
                         <li><strong>Inserir → Módulo</strong></li>
                         <li>Apague o código antigo e cole o novo</li>
                         <li><strong>F5</strong> para executar</li>
                       </ol>
+                      <p className="mt-2">
+                        Se você salvou os PDFs em outra pasta, ajuste a linha <strong>sPasta</strong> no início do script.
+                      </p>
                     </div>
                   </div>
                 )}
@@ -513,7 +638,19 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
                 {/* Estado vazio */}
                 {pagamentos.length === 0 && (
                   <div className="rounded-lg border border-border bg-muted/40 px-4 py-8 text-center text-sm text-muted-foreground">
-                    Nenhum pagamento USDT com hash cadastrado neste mês.
+                    Nenhum pagamento com comprovante cadastrado neste mês.
+                  </div>
+                )}
+
+                {/* Mailto não anexa arquivos — limitação do protocolo */}
+                {pagamentos.some(p => selected.has(p.id) && temPdf(p)) && (
+                  <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                    <span>
+                      O Mailto não permite anexar arquivos (limitação do navegador). Os PDFs
+                      {' '}<strong>não irão anexados</strong> — anexe manualmente no cliente de email, ou
+                      use o método <strong>VBA</strong>, que anexa automaticamente.
+                    </span>
                   </div>
                 )}
 
@@ -574,7 +711,16 @@ export default function EmailVbaDialog({ pagamentos }: Props) {
                               }`}>
                                 {p.tipo === 'comissao' ? 'Comissão' : 'Salário'}
                               </span>
-                              <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} USDT</span>
+                              <span className="text-sm font-semibold tabular-nums text-foreground">{valorFmt} {p.moeda}</span>
+                              {temPdf(p) && (
+                                <span
+                                  title="Comprovante PDF será anexado"
+                                  className="inline-flex items-center gap-1 rounded-full bg-blue-500/15 px-2 py-0.5 text-xs font-medium text-blue-400"
+                                >
+                                  <Paperclip className="h-3 w-3" />
+                                  PDF
+                                </span>
+                              )}
                             </div>
                             <p className="text-xs text-muted-foreground mt-0.5 truncate">{descricao}</p>
                             {temEmail && (

--- a/src/app/historico/page.tsx
+++ b/src/app/historico/page.tsx
@@ -15,6 +15,7 @@ import EmailVbaDialog from './email-vba-dialog'
 import type { HistoricoParaEmail } from './email-vba-dialog'
 import CollapsibleSection from './collapsible-section'
 import RefreshButton from './refresh-button'
+import BaixarPdfsDialog from './baixar-pdfs-dialog'
 
 const MESES = [
   'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
@@ -76,9 +77,15 @@ function PagamentoCard({ p }: { p: HistoricoPagamento }) {
 
       <div className="px-5 py-3 space-y-2">
         <p className="text-sm text-muted-foreground">{p.descricao}</p>
-        <ComprovanteEditor id={p.id} comprovante={p.comprovante} moeda={p.moeda} />
+        <ComprovanteEditor
+          id={p.id}
+          comprovante={p.comprovante}
+          comprovanteArquivo={p.comprovante_arquivo}
+          comprovanteArquivoNome={p.comprovante_arquivo_nome}
+          moeda={p.moeda}
+        />
         <NfEditor id={p.id} notaFiscal={p.nota_fiscal} />
-        {p.moeda !== 'BRL' && <EmailStatusEditor id={p.id} emailEnviado={p.email_enviado} />}
+        <EmailStatusEditor id={p.id} emailEnviado={p.email_enviado} />
       </div>
     </div>
   )
@@ -97,16 +104,39 @@ export default async function HistoricoPage({
   const nomeMes = `${MESES[mesNum - 1]} ${anoNum}`
 
   const supabase = await createClient()
-  const { data: pagamentos, error } = await supabase
-    .from('historico_pagamentos')
-    .select('*, prestadores(email)')
-    .eq('mes_referencia', mesReferencia)
-    .order('pago_em', { ascending: false })
+  const [{ data: pagamentos, error }, { data: comComprovante }] = await Promise.all([
+    supabase
+      .from('historico_pagamentos')
+      .select('*, prestadores(email)')
+      .eq('mes_referencia', mesReferencia)
+      .order('pago_em', { ascending: false }),
+    // Prestadores e meses que possuem PDF — alimenta os filtros do download em lote
+    supabase
+      .from('historico_pagamentos')
+      .select('prestador_id, prestador_nome, mes_referencia')
+      .not('comprovante_arquivo', 'is', null),
+  ])
+
+  const prestadoresComPdf = Array.from(
+    new Map(
+      (comComprovante ?? [])
+        .filter(p => p.prestador_id)
+        .map(p => [p.prestador_id as string, p.prestador_nome as string]),
+    ),
+  )
+    .map(([id, nome]) => ({ id, nome }))
+    .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
+
+  const mesesComPdf = Array.from(
+    new Set((comComprovante ?? []).map(p => (p.mes_referencia as string).substring(0, 7))),
+  ).sort((a, b) => b.localeCompare(a))
 
   const lista: HistoricoPagamento[] = (pagamentos ?? []) as HistoricoPagamento[]
 
   const pagamentosEmail: HistoricoParaEmail[] = (pagamentos ?? [])
-    .filter(p => p.moeda !== 'BRL' && p.comprovante && !p.email_enviado)
+    .filter(p => !p.email_enviado && (
+      (p.moeda !== 'BRL' && p.comprovante) || (p.moeda === 'BRL' && p.comprovante_arquivo)
+    ))
     .map(p => ({
       id: p.id,
       tipo: p.tipo,
@@ -114,7 +144,9 @@ export default async function HistoricoPage({
       prestador_email: (p.prestadores as { email: string } | null)?.email ?? null,
       descricao: p.descricao,
       valor: p.valor,
-      comprovante: p.comprovante!,
+      moeda: p.moeda,
+      comprovante: p.comprovante,
+      comprovante_arquivo: p.comprovante_arquivo,
       mes_referencia: p.mes_referencia,
     }))
 
@@ -172,6 +204,11 @@ export default async function HistoricoPage({
           </div>
           <div className="flex items-center gap-3">
             <RefreshButton />
+            <BaixarPdfsDialog
+              mesAtual={mesAtual}
+              prestadores={prestadoresComPdf}
+              meses={mesesComPdf}
+            />
             <EmailVbaDialog pagamentos={pagamentosEmail} />
             <MesSelector mesAtual={mesAtual} />
           </div>

--- a/src/app/resumo/actions.ts
+++ b/src/app/resumo/actions.ts
@@ -40,23 +40,28 @@ export async function registrarPagamentoSalario(input: RegistrarPagamentoSalario
   const orgId = await getOrganizationId()
   const supabase = await createClient()
 
-  const { error } = await supabase.from('historico_pagamentos').insert({
-    tipo: 'salario',
-    referencia_id: null,
-    comissao_prestador_id: null,
-    prestador_id: input.prestadorId,
-    prestador_nome: input.prestadorNome,
-    descricao: input.descricao,
-    valor: input.valor,
-    moeda: input.moeda,
-    comprovante: input.comprovante,
-    nota_fiscal: input.notaFiscal,
-    mes_referencia: input.mesReferencia,
-    organization_id: orgId,
-    parcelas_emprestimo_ids: input.parcelaIds.length > 0 ? input.parcelaIds : null,
-  })
+  const { data, error } = await supabase
+    .from('historico_pagamentos')
+    .insert({
+      tipo: 'salario',
+      referencia_id: null,
+      comissao_prestador_id: null,
+      prestador_id: input.prestadorId,
+      prestador_nome: input.prestadorNome,
+      descricao: input.descricao,
+      valor: input.valor,
+      moeda: input.moeda,
+      comprovante: input.comprovante,
+      nota_fiscal: input.notaFiscal,
+      mes_referencia: input.mesReferencia,
+      organization_id: orgId,
+      parcelas_emprestimo_ids: input.parcelaIds.length > 0 ? input.parcelaIds : null,
+    })
+    .select('id')
+    .single()
 
   if (error) throw new Error('Erro ao registrar pagamento.')
+  const historicoId = data.id
 
   if (input.parcelaIds.length > 0) {
     const { data: parcelasInfo } = await supabase
@@ -98,6 +103,8 @@ export async function registrarPagamentoSalario(input: RegistrarPagamentoSalario
   revalidatePath('/resumo')
   revalidatePath('/historico')
   revalidatePath('/emprestimos')
+
+  return { historicoId }
 }
 
 interface ComissaoParaPagarInput {
@@ -125,7 +132,7 @@ interface RegistrarPagamentoCombinado {
 }
 
 export async function registrarPagamentoCombinado(input: RegistrarPagamentoCombinado) {
-  await registrarPagamentoSalario({
+  const salario = await registrarPagamentoSalario({
     prestadorId: input.prestadorId,
     prestadorNome: input.prestadorNome,
     valor: input.valorSalario,
@@ -152,4 +159,6 @@ export async function registrarPagamentoCombinado(input: RegistrarPagamentoCombi
       notaFiscal: c.notaFiscal,
     })
   }
+
+  return salario
 }

--- a/src/app/resumo/registrar-pagamento-dialog.tsx
+++ b/src/app/resumo/registrar-pagamento-dialog.tsx
@@ -6,6 +6,8 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { X, Loader2, Wallet, QrCode, ChevronLeft, ChevronRight, DollarSign } from 'lucide-react'
 import { registrarPagamentoSalario, registrarPagamentoCombinado } from './actions'
+import { atualizarComprovanteArquivo } from '../historico/actions'
+import ArquivoComprovanteField from '@/components/arquivo-comprovante-field'
 import type { MoedaSimples } from '@/lib/types'
 
 export interface ComissaoPendente {
@@ -151,6 +153,7 @@ export default function RegistrarPagamentoSalarioDialog({ context, onClose }: Pr
   const [serverError, setServerError] = useState<string | null>(null)
   const [comissaoEdits, setComissaoEdits] = useState<Record<string, ComissaoEdit>>({})
   const [replicarHash, setReplicarHash] = useState(false)
+  const [arquivoSalario, setArquivoSalario] = useState<File | null>(null)
 
   const form = useForm<FormData>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -169,6 +172,7 @@ export default function RegistrarPagamentoSalarioDialog({ context, onClose }: Pr
     setSelectedMes(context.defaultMes)
     setServerError(null)
     setReplicarHash(false)
+    setArquivoSalario(null)
     const init: Record<string, ComissaoEdit> = {}
     for (const c of context.comissoesSelecionadas) {
       init[c.cpId] = { valor: parseFloat(c.valor.toFixed(4)).toString(), comprovante: '' }
@@ -212,8 +216,9 @@ export default function RegistrarPagamentoSalarioDialog({ context, onClose }: Pr
 
     startTransition(async () => {
       try {
+        let historicoId: string
         if (context.comissoesSelecionadas.length > 0) {
-          await registrarPagamentoCombinado({
+          const res = await registrarPagamentoCombinado({
             prestadorId: context.prestadorId,
             prestadorNome: context.prestadorNome,
             valorSalario: data.valor,
@@ -230,8 +235,9 @@ export default function RegistrarPagamentoSalarioDialog({ context, onClose }: Pr
               return { cpId: c.cpId, comissaoId: c.comissaoId, tipo: c.tipo, descricao: c.descricao, valor, moeda: c.moeda, notaFiscal: c.notaFiscal, comprovante }
             }),
           })
+          historicoId = res.historicoId
         } else {
-          await registrarPagamentoSalario({
+          const res = await registrarPagamentoSalario({
             prestadorId: context.prestadorId,
             prestadorNome: context.prestadorNome,
             valor: data.valor,
@@ -242,6 +248,12 @@ export default function RegistrarPagamentoSalarioDialog({ context, onClose }: Pr
             notaFiscal: context.notaFiscal,
             comprovante: data.comprovante?.trim() || null,
           })
+          historicoId = res.historicoId
+        }
+        if (arquivoSalario) {
+          const fd = new FormData()
+          fd.append('arquivo', arquivoSalario)
+          await atualizarComprovanteArquivo(historicoId, fd)
         }
         onClose(selectedMes)
       } catch (e) {
@@ -330,18 +342,41 @@ export default function RegistrarPagamentoSalarioDialog({ context, onClose }: Pr
                 <FieldError message={form.formState.errors.valor?.message} />
               </div>
 
-              {/* Hash do salário */}
-              <div className="space-y-2">
-                <label className="block text-sm font-medium text-foreground mb-1.5">
-                  {isUsdt ? 'Hash da transação' : 'Comprovante PIX'}{' '}
-                  <span className="text-muted-foreground font-normal">(opcional)</span>
-                </label>
-                <input
-                  {...form.register('comprovante')}
-                  type="text"
-                  placeholder={isUsdt ? '0x...' : 'ID ou descrição do comprovante'}
-                  className={inputClass + ' font-mono'}
-                />
+              {/* Hash / comprovante do salário */}
+              <div className="space-y-3">
+                {isUsdt ? (
+                  <>
+                    <label className="block text-sm font-medium text-foreground mb-1.5">
+                      Hash da transação <span className="text-muted-foreground font-normal">(opcional)</span>
+                    </label>
+                    <input
+                      {...form.register('comprovante')}
+                      type="text"
+                      placeholder="0x..."
+                      className={inputClass + ' font-mono'}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1.5">
+                        Comprovante PIX (PDF) <span className="text-muted-foreground font-normal">(opcional)</span>
+                      </label>
+                      <ArquivoComprovanteField onArquivo={setArquivoSalario} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1.5">
+                        ID ou descrição <span className="text-muted-foreground font-normal">(opcional)</span>
+                      </label>
+                      <input
+                        {...form.register('comprovante')}
+                        type="text"
+                        placeholder="ID ou descrição do comprovante"
+                        className={inputClass + ' font-mono'}
+                      />
+                    </div>
+                  </>
+                )}
                 {temComissoes && (
                   <label className="flex items-center gap-2 cursor-pointer select-none w-fit">
                     <input

--- a/src/components/abrir-comprovante-button.tsx
+++ b/src/components/abrir-comprovante-button.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import { FileText, Loader2, Download } from 'lucide-react'
+
+interface Props {
+  historicoId: string
+  label?: string
+  className?: string
+  downloadClassName?: string
+}
+
+export default function AbrirComprovanteButton({
+  historicoId,
+  label = 'PDF',
+  className,
+  downloadClassName,
+}: Props) {
+  const [carregando, setCarregando] = useState(false)
+  const [baixando, setBaixando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
+  async function buscarUrl(baixar: boolean): Promise<string> {
+    const qs = baixar ? '?json=1&download=1' : '?json=1'
+    const res = await fetch(`/api/comprovantes/${historicoId}${qs}`)
+    if (!res.ok) throw new Error()
+    const { url } = await res.json()
+    return url
+  }
+
+  async function abrir() {
+    setCarregando(true)
+    setErro(null)
+    // Abre a aba antes do await para não ser bloqueada como popup.
+    // Sem 'noopener' aqui: com ele o browser retorna null e perdemos a referência.
+    const aba = window.open('', '_blank')
+    if (!aba) {
+      setCarregando(false)
+      setErro('Permita pop-ups para abrir o comprovante.')
+      return
+    }
+    try {
+      const url = await buscarUrl(false)
+      aba.opener = null
+      aba.location.replace(url)
+    } catch {
+      aba.close()
+      setErro('Não foi possível abrir o comprovante.')
+    } finally {
+      setCarregando(false)
+    }
+  }
+
+  async function baixar() {
+    setBaixando(true)
+    setErro(null)
+    try {
+      const url = await buscarUrl(true)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = ''
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+    } catch {
+      setErro('Não foi possível baixar o comprovante.')
+    } finally {
+      setBaixando(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={abrir}
+        disabled={carregando}
+        title="Abrir comprovante PDF em nova aba"
+        className={className}
+      >
+        {carregando ? <Loader2 className="h-3 w-3 animate-spin" /> : <FileText className="h-3 w-3" />}
+        {label}
+      </button>
+      <button
+        type="button"
+        onClick={baixar}
+        disabled={baixando}
+        title="Baixar comprovante PDF"
+        className={downloadClassName ?? className}
+      >
+        {baixando ? <Loader2 className="h-3 w-3 animate-spin" /> : <Download className="h-3 w-3" />}
+      </button>
+      {erro && <span className="text-xs text-destructive">{erro}</span>}
+    </>
+  )
+}

--- a/src/components/arquivo-comprovante-field.tsx
+++ b/src/components/arquivo-comprovante-field.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { FileText, X } from 'lucide-react'
+
+const MAX_PDF_BYTES = 5 * 1024 * 1024
+
+interface Props {
+  onArquivo: (f: File | null) => void
+}
+
+export default function ArquivoComprovanteField({ onArquivo }: Props) {
+  const [arquivo, setArquivo] = useState<File | null>(null)
+  const [erro, setErro] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function handleChange(file: File | null) {
+    setErro(null)
+    if (!file) {
+      setArquivo(null)
+      onArquivo(null)
+      return
+    }
+    if (file.type !== 'application/pdf') {
+      setErro('Apenas arquivos PDF são aceitos.')
+      setArquivo(null)
+      onArquivo(null)
+      return
+    }
+    if (file.size > MAX_PDF_BYTES) {
+      setErro('O PDF deve ter no máximo 5 MB.')
+      setArquivo(null)
+      onArquivo(null)
+      return
+    }
+    setArquivo(file)
+    onArquivo(file)
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        className="hidden"
+        onChange={e => handleChange(e.target.files?.[0] ?? null)}
+      />
+
+      {arquivo ? (
+        <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-xs">
+          <FileText className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span className="min-w-0 flex-1 truncate text-emerald-600 dark:text-emerald-400">{arquivo.name}</span>
+          <button
+            type="button"
+            onClick={() => {
+              setArquivo(null)
+              onArquivo(null)
+              if (inputRef.current) inputRef.current.value = ''
+            }}
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground transition-colors"
+            title="Remover arquivo"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="w-full rounded-lg border border-dashed border-input bg-transparent px-3 py-2 text-left text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        >
+          Anexar comprovante (PDF) — opcional
+        </button>
+      )}
+
+      {erro && <p className="text-xs text-destructive">{erro}</p>}
+    </div>
+  )
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,6 +103,9 @@ export interface HistoricoPagamento {
   valor: number
   moeda: MoedaSimples
   comprovante: string | null
+  comprovante_arquivo: string | null
+  comprovante_arquivo_nome: string | null
+  comprovante_arquivo_tamanho: number | null
   nota_fiscal: boolean
   email_enviado: boolean
   mes_referencia: string

--- a/supabase/migrations/017_comprovante_pdf.sql
+++ b/supabase/migrations/017_comprovante_pdf.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Comprovante PIX como PDF anexado (Supabase Storage)
+-- ============================================================
+
+-- Colunas de metadados do arquivo anexado em historico_pagamentos
+ALTER TABLE historico_pagamentos
+  ADD COLUMN comprovante_arquivo TEXT,          -- path do objeto no bucket
+  ADD COLUMN comprovante_arquivo_nome TEXT,      -- nome original do arquivo
+  ADD COLUMN comprovante_arquivo_tamanho BIGINT; -- tamanho em bytes
+
+-- Garantir RLS habilitado (idempotente)
+ALTER TABLE historico_pagamentos ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- Bucket de storage privado
+-- ============================================================
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('comprovantes', 'comprovantes', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- Policies do bucket — isolamento por organização via prefixo
+-- O objeto é nomeado {organization_id}/{historico_id}/{arquivo}.pdf
+-- ============================================================
+
+-- Insert: só dentro da própria organização
+CREATE POLICY "org_isolation_insert" ON storage.objects
+  FOR INSERT WITH CHECK (
+    bucket_id = 'comprovantes'
+    AND (storage.foldername(name))[1] = (SELECT get_user_org_id())::text
+  );
+
+-- Select: só da própria organização
+CREATE POLICY "org_isolation_select" ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'comprovantes'
+    AND (storage.foldername(name))[1] = (SELECT get_user_org_id())::text
+  );
+
+-- Delete: só da própria organização
+CREATE POLICY "org_isolation_delete" ON storage.objects
+  FOR DELETE USING (
+    bucket_id = 'comprovantes'
+    AND (storage.foldername(name))[1] = (SELECT get_user_org_id())::text
+  );


### PR DESCRIPTION
## Resumo

Permite anexar o comprovante PIX como arquivo **PDF** nos pagamentos em BRL — tanto no registro (resumo, comissões) quanto na edição do histórico — e persiste o arquivo no Supabase Storage, com isolamento por organização.

## Principais mudanças

### Banco de dados (migration `017`)
- Bucket de storage privado `comprovantes`, com policies que restringem acesso ao arquivo por organização.
- Novas colunas em `historico_pagamentos`: `comprovante_arquivo` (caminho no bucket), `comprovante_arquivo_nome`, `comprovante_arquivo_tamanho`.

### Upload do comprovante
- Campo texto (ID/descrição) continua **opcional** para BRL; o anexo PDF também é **opcional**.
- Como Server Actions têm limite de body de 1 MB, o upload é feito em **2 etapas**: o pagamento é registrado primeiro e o PDF é enviado na sequência (arquivos até 5 MB).
- Validação de tipo (`application/pdf`) e tamanho (≤ 5 MB) no cliente e no servidor.
- Upload/remoção do PDF também direto do histórico de pagamentos.

### Visualização e download
- **Abrir** o PDF em nova aba **no domínio do Supabase** (URL assinada por 60s), evitando que o navegador capture o link para um PWA instalado.
- **Baixar** o PDF ao lado do botão de abrir.
- Permissão validada no servidor: a URL assinada só é emitida se o pagamento pertencer à organização do usuário.

### Envio por email
- **VBA/Outlook**: o script agora anexa os PDFs baixados automaticamente (`sPasta` = Downloads) e verifica antes de enviar se todos os anexos existem, abortando se faltar algum.
- **Mailto**: o protocolo não permite anexar arquivos — o fluxo avisa o usuário disso e sugere o método VBA.

### Download em lote no histórico
- Novo botão **"Baixar PDF's"** ao lado de "Atualizar".
- Abre um modal com filtros combináveis por **mês** e/ou **prestador**, exportando todos os PDFs correspondentes em um único arquivo `.zip`.

## Como testar

1. Aplicar a migration `supabase/migrations/017_comprovante_pdf.sql`.
2. Registrar um pagamento BRL anexando um PDF → conferir no histórico o link de abrir/baixar.
3. No histórico, usar "Baixar PDF's" filtrando por mês e/ou prestador → baixar o `.zip`.
4. Enviar email via VBA com pagamento BRL → conferir que o anexo é adicionado.